### PR TITLE
Fix sample docs-conformance findings (A1, A2, A3) and 04-swarm host grant

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -38,10 +38,10 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -49,7 +49,7 @@ jobs:
         run: uv sync --all-extras --group test
 
       - name: Azure login (OIDC)
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/tests-offline.yml
+++ b/.github/workflows/tests-offline.yml
@@ -16,10 +16,10 @@ jobs:
   offline-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -40,38 +40,25 @@ The `aca` CLI itself is installed in the next section.
 ### Linux / macOS
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
-```
-
-Pin a specific version:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh \
-  | ACA_VERSION=aca-cli-v0.1.0-early-access sh
+curl -fsSL https://aka.ms/aca-cli-install | sh
 ```
 
 ### Windows (PowerShell)
 
 ```powershell
-irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1 | iex
-```
-
-Pin a specific version:
-
-```powershell
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Version aca-cli-v0.1.0-early-access
+irm https://aka.ms/aca-cli-install-ps | iex
 ```
 
 ### Uninstall
 
 ```bash
 # Linux / macOS
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh -s -- --uninstall
+curl -fsSL https://aka.ms/aca-cli-install | sh -s -- --uninstall
 ```
 
 ```powershell
 # Windows
-& ([scriptblock]::Create((irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1))) -Uninstall
+& ([scriptblock]::Create((irm https://aka.ms/aca-cli-install-ps))) -Uninstall
 ```
 
 ### Supported platforms

--- a/cli/samples/02-coding-agents/gh-copilot-cli/cli/policy.yaml
+++ b/cli/samples/02-coding-agents/gh-copilot-cli/cli/policy.yaml
@@ -1,4 +1,4 @@
-# ACA egress policy — Copilot CLI scenario (portal-paste flow).
+# ACA egress policy, Copilot CLI scenario (portal-paste flow).
 #
 # Header values contain the literal placeholder "PASTE_PAT_HERE" instead
 # of a real PAT. After this policy is applied, open the sandbox in
@@ -6,11 +6,17 @@
 # "PASTE_PAT_HERE" in each Transform rule's Value with your GitHub PAT.
 # The scheme prefix (Bearer / token) must stay.
 #
-# IMPORTANT: do NOT add a hostRule for *.githubcopilot.com — host rules
+# IMPORTANT: do NOT add a hostRule for *.githubcopilot.com, host rules
 # short-circuit before transform rules fire, which would silently drop
 # the injected Authorization header.
 
 defaultAction: Deny
+
+# Transform rules rewrite request headers (the Authorization injection
+# below), which requires full traffic inspection so the proxy can read
+# and modify the request. Without this, Set-header transforms do not
+# fire and the injected PAT never reaches the upstream.
+trafficInspection: Full
 
 hostRules:
   - pattern: "*.github.com"

--- a/cli/samples/04-swarms/01-sandbox-inception/cli/run.sh
+++ b/cli/samples/04-swarms/01-sandbox-inception/cli/run.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Sandbox inception swarm — aca CLI variant.
+# Sandbox inception swarm, aca CLI variant.
 #
 # Story: a sandbox in orchestrator group A uses its group's
 # system-assigned managed identity to create and drive N worker
-# sandboxes in a separate group B — no credential is ever placed
+# sandboxes in a separate group B, no credential is ever placed
 # inside the agent. Demonstration task: Monte Carlo Pi across the
 # workers, aggregated by the orchestrator.
 #
-# The script is built so `aca config` is the obvious win — neither the
+# The script is built so `aca config` is the obvious win, neither the
 # host nor the orchestrator carries `--subscription / --resource-group /
 # --group / --managed-identity` flags on individual `aca` calls.
 #
@@ -33,12 +33,12 @@ if [[ -f "$dir/.env" ]]; then
     . "$dir/.env"
     set +a
 else
-    echo "error: could not find samples/.env — run setup/cli/setup.sh first" >&2
+    echo "error: could not find samples/.env, run setup/cli/setup.sh first" >&2
     exit 1
 fi
 
 ROLE_NAME="Container Apps SandboxGroup Data Owner"
-CLI_INSTALL_URL="https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh"
+CLI_INSTALL_URL="https://aka.ms/aca-cli-install"
 WORKERS=4
 DARTS_PER_WORKER=1000000
 SUFFIX="$(printf '%08x' "$(( (RANDOM<<15) ^ RANDOM ^ ($(date +%s) & 0xffff) ))")"
@@ -75,13 +75,13 @@ aca sandboxgroup create \
 # needing --group on each line. This is the aca config showcase.
 aca config sandbox set --group "$ORCH_GROUP" --region "$ACA_SANDBOXGROUP_REGION" >/dev/null
 
-aca sandboxgroup identity assign --name "$ORCH_GROUP" --system-assigned >/dev/null
+aca sandboxgroup identity assign --group "$ORCH_GROUP" --system-assigned >/dev/null
 
-PRINCIPAL_ID="$(aca sandboxgroup identity show --name "$ORCH_GROUP" -o json \
+PRINCIPAL_ID="$(aca sandboxgroup identity show --group "$ORCH_GROUP" -o json \
     | grep -oE '"principalId"[^"]*"[0-9a-fA-F-]+"' \
     | grep -oE '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')"
 if [[ -z "$PRINCIPAL_ID" ]]; then
-    echo "error: orchestrator group has no principalId — MI not enabled?" >&2
+    echo "error: orchestrator group has no principalId, MI not enabled?" >&2
     exit 1
 fi
 echo "    principalId: $PRINCIPAL_ID"
@@ -102,7 +102,7 @@ for attempt in 1 2 3 4 5 6 7 8 9 10; do
     if aca sandboxgroup role create \
             --role "$ROLE_NAME" \
             --principal-id "$PRINCIPAL_ID" \
-            --name "$WORKER_GROUP" 2>/tmp/role.err; then
+            --group "$WORKER_GROUP" 2>/tmp/role.err; then
         break
     fi
     if grep -q "RoleAssignmentExists\|already exists" /tmp/role.err 2>/dev/null; then
@@ -118,6 +118,30 @@ for attempt in 1 2 3 4 5 6 7 8 9 10; do
     sleep 10
 done
 rm -f /tmp/role.err
+
+# The host created the orchestrator group fresh, so it has no data-plane
+# grant there yet (setup only grants on the samples group). Grant the host
+# Data Owner on the orchestrator group so it can boot the orchestrator
+# sandbox below.
+HOST_ID="$(az ad signed-in-user show --query id -o tsv 2>/dev/null)"
+if [[ -z "$HOST_ID" ]]; then
+    echo "error: could not resolve signed-in user id (run 'az login')" >&2
+    exit 1
+fi
+echo "==> Granting '$ROLE_NAME' on $ORCH_GROUP -> host user..."
+if ! aca sandboxgroup role create \
+        --role "$ROLE_NAME" \
+        --principal-id "$HOST_ID" \
+        --group "$ORCH_GROUP" 2>/tmp/hostrole.err; then
+    if grep -q "RoleAssignmentExists\|already exists" /tmp/hostrole.err 2>/dev/null; then
+        echo "    host role already assigned"
+    else
+        cat /tmp/hostrole.err >&2
+        echo "error: host role grant on $ORCH_GROUP failed" >&2
+        exit 1
+    fi
+fi
+rm -f /tmp/hostrole.err
 
 echo "==> Waiting 20s for RBAC propagation..."
 sleep 20
@@ -147,7 +171,7 @@ cat > "$SWARM_SH" <<'INNER_EOF'
 #!/usr/bin/env bash
 # Runs INSIDE the orchestrator sandbox. Uses the group's MI (via
 # ACA_SANDBOX_MANAGED_IDENTITY=system) to fan out N worker sandbox
-# creates + execs in the WORKER group — same `aca` binary, but the
+# creates + execs in the WORKER group, same `aca` binary, but the
 # context env vars point at the worker group rather than the
 # orchestrator group. The block below is the aca config showcase: every
 # `aca` call below is parameter-free because the context is already set.
@@ -232,7 +256,7 @@ while read -r line; do
 done <<< "$SWARM_OUTPUT"
 
 if [[ "$TOTAL_DARTS" -eq 0 ]]; then
-    echo "error: no worker results parsed — see output above" >&2
+    echo "error: no worker results parsed, see output above" >&2
     exit 1
 fi
 PI=$(awk "BEGIN{pi=4*$TOTAL_INSIDE/$TOTAL_DARTS; err=pi-3.141592653589793; if(err<0)err=-err; printf \"pi ≈ %.6f  (error %.2e)\", pi, err}")

--- a/cli/samples/04-swarms/02-shared-blob-memory/cli/run.sh
+++ b/cli/samples/04-swarms/02-shared-blob-memory/cli/run.sh
@@ -115,10 +115,10 @@ for attempt in 1 2 3 4 5 6 7 8 9 10; do
 done
 rm -f /tmp/role.err
 
-# The host created the orchestrator group fresh, so it has no data-plane
-# grant there yet (setup only grants on the samples group). Grant the host
-# Data Owner on the orchestrator group so it can boot the orchestrator
-# sandbox below.
+# The host created both groups fresh, so it has no data-plane grant on
+# either yet (setup only grants on the samples group). Grant the host Data
+# Owner on the orchestrator group so it can boot the orchestrator sandbox,
+# and on the worker group so it can create the shared volume below.
 HOST_ID="$(az ad signed-in-user show --query id -o tsv 2>/dev/null)"
 if [[ -z "$HOST_ID" ]]; then
     echo "error: could not resolve signed-in user id (run 'az login')" >&2
@@ -139,12 +139,28 @@ if ! aca sandboxgroup role create \
 fi
 rm -f /tmp/hostrole.err
 
+echo "==> Granting '$ROLE_NAME' on $WORKER_GROUP -> host user..."
+if ! aca sandboxgroup role create \
+        --role "$ROLE_NAME" \
+        --principal-id "$HOST_ID" \
+        --group "$WORKER_GROUP" 2>/tmp/hostrole.err; then
+    if grep -q "RoleAssignmentExists\|already exists" /tmp/hostrole.err 2>/dev/null; then
+        echo "    host role already assigned"
+    else
+        cat /tmp/hostrole.err >&2
+        echo "error: host role grant on $WORKER_GROUP failed" >&2
+        exit 1
+    fi
+fi
+rm -f /tmp/hostrole.err
+
 echo "==> Waiting 20s for RBAC propagation..."
 sleep 20
 
 echo "==> Creating AzureBlob volume '$VOLUME_NAME' on $WORKER_GROUP..."
-# Volume creation uses the host's `az login` against the worker group;
-# the orchestrator MI will later mount it (Data Owner covers both).
+# Volume creation uses the host's `az login` against the worker group
+# (the host grant above); the orchestrator MI later mounts it via its own
+# worker-group grant.
 # Briefly flip context to the worker group, create, then flip back so
 # the rest of the host script keeps targeting the orchestrator group.
 aca config sandbox set --group "$WORKER_GROUP" --region "$ACA_SANDBOXGROUP_REGION" >/dev/null

--- a/cli/samples/04-swarms/02-shared-blob-memory/cli/run.sh
+++ b/cli/samples/04-swarms/02-shared-blob-memory/cli/run.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
-# Shared-blob memory swarm — aca CLI variant.
+# Shared-blob memory swarm, aca CLI variant.
 #
 # Same shape as 01-sandbox-inception/cli, plus: the worker group owns an
 # AzureBlob volume that every worker and the aggregator mount at
 # /mnt/shared. Workers checkpoint JSON to it; an aggregator sandbox
 # (spawned after the workers exit) globs and aggregates. The platform
-# brokers identity/storage behind the mount — no `azure-storage-blob`,
+# brokers identity/storage behind the mount, no `azure-storage-blob`,
 # no SAS, no extra role grants.
 #
 # The same `aca config` ergonomics from variant 01 apply: neither the
@@ -31,12 +31,12 @@ if [[ -f "$dir/.env" ]]; then
     . "$dir/.env"
     set +a
 else
-    echo "error: could not find samples/.env — run setup/cli/setup.sh first" >&2
+    echo "error: could not find samples/.env, run setup/cli/setup.sh first" >&2
     exit 1
 fi
 
 ROLE_NAME="Container Apps SandboxGroup Data Owner"
-CLI_INSTALL_URL="https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh"
+CLI_INSTALL_URL="https://aka.ms/aca-cli-install"
 WORKERS=4
 DARTS_PER_WORKER=1000000
 SUFFIX="$(printf '%08x' "$(( (RANDOM<<15) ^ RANDOM ^ ($(date +%s) & 0xffff) ))")"
@@ -76,13 +76,13 @@ aca sandboxgroup create \
 
 aca config sandbox set --group "$ORCH_GROUP" --region "$ACA_SANDBOXGROUP_REGION" >/dev/null
 
-aca sandboxgroup identity assign --name "$ORCH_GROUP" --system-assigned >/dev/null
+aca sandboxgroup identity assign --group "$ORCH_GROUP" --system-assigned >/dev/null
 
-PRINCIPAL_ID="$(aca sandboxgroup identity show --name "$ORCH_GROUP" -o json \
+PRINCIPAL_ID="$(aca sandboxgroup identity show --group "$ORCH_GROUP" -o json \
     | grep -oE '"principalId"[^"]*"[0-9a-fA-F-]+"' \
     | grep -oE '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')"
 if [[ -z "$PRINCIPAL_ID" ]]; then
-    echo "error: orchestrator group has no principalId — MI not enabled?" >&2
+    echo "error: orchestrator group has no principalId, MI not enabled?" >&2
     exit 1
 fi
 echo "    principalId: $PRINCIPAL_ID"
@@ -98,7 +98,7 @@ for attempt in 1 2 3 4 5 6 7 8 9 10; do
     if aca sandboxgroup role create \
             --role "$ROLE_NAME" \
             --principal-id "$PRINCIPAL_ID" \
-            --name "$WORKER_GROUP" 2>/tmp/role.err; then
+            --group "$WORKER_GROUP" 2>/tmp/role.err; then
         break
     fi
     if grep -q "RoleAssignmentExists\|already exists" /tmp/role.err 2>/dev/null; then
@@ -114,6 +114,30 @@ for attempt in 1 2 3 4 5 6 7 8 9 10; do
     sleep 10
 done
 rm -f /tmp/role.err
+
+# The host created the orchestrator group fresh, so it has no data-plane
+# grant there yet (setup only grants on the samples group). Grant the host
+# Data Owner on the orchestrator group so it can boot the orchestrator
+# sandbox below.
+HOST_ID="$(az ad signed-in-user show --query id -o tsv 2>/dev/null)"
+if [[ -z "$HOST_ID" ]]; then
+    echo "error: could not resolve signed-in user id (run 'az login')" >&2
+    exit 1
+fi
+echo "==> Granting '$ROLE_NAME' on $ORCH_GROUP -> host user..."
+if ! aca sandboxgroup role create \
+        --role "$ROLE_NAME" \
+        --principal-id "$HOST_ID" \
+        --group "$ORCH_GROUP" 2>/tmp/hostrole.err; then
+    if grep -q "RoleAssignmentExists\|already exists" /tmp/hostrole.err 2>/dev/null; then
+        echo "    host role already assigned"
+    else
+        cat /tmp/hostrole.err >&2
+        echo "error: host role grant on $ORCH_GROUP failed" >&2
+        exit 1
+    fi
+fi
+rm -f /tmp/hostrole.err
 
 echo "==> Waiting 20s for RBAC propagation..."
 sleep 20
@@ -269,7 +293,7 @@ TOTAL_INSIDE="$(printf '%s\n' "$RESULT_LINE" | grep -oE 'INSIDE=[0-9]+' | cut -d
 TOTAL_DARTS="$( printf '%s\n' "$RESULT_LINE" | grep -oE 'TOTAL=[0-9]+'  | cut -d= -f2)"
 
 if [[ -z "${TOTAL_DARTS:-}" || "$TOTAL_DARTS" -eq 0 ]]; then
-    echo "error: aggregator did not report a RESULT line — see output above" >&2
+    echo "error: aggregator did not report a RESULT line, see output above" >&2
     exit 1
 fi
 PI=$(awk "BEGIN{pi=4*$TOTAL_INSIDE/$TOTAL_DARTS; err=pi-3.141592653589793; if(err<0)err=-err; printf \"pi ≈ %.6f  (error %.2e)\", pi, err}")

--- a/python/samples/04-swarms/01-sandbox-inception/python/swarm.py
+++ b/python/samples/04-swarms/01-sandbox-inception/python/swarm.py
@@ -1,10 +1,10 @@
-"""Sandbox inception swarm — orchestrator sandbox spawns N workers in another group.
+"""Sandbox inception swarm, orchestrator sandbox spawns N workers in another group.
 
 The host script provisions two fresh per-run sandbox groups (orchestrator
 with SystemAssigned managed identity, plus a worker group with `Data
 Owner` granted to the orchestrator's MI), boots an orchestrator
 sandbox in the orchestrator group, then asks it to fan out N=4 Monte
-Carlo Pi workers in the worker group **using only managed identity** —
+Carlo Pi workers in the worker group **using only managed identity**,
 no credential is ever materialised inside the agent code.
 
 The full scenario story (architecture diagram + production tips) lives
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import subprocess
 import sys
 import textwrap
 import time
@@ -152,7 +153,12 @@ def _load_env() -> None:
         )
 
 
-def _assign_role(auth: AuthorizationManagementClient, scope: str, principal_id: str) -> None:
+def _assign_role(
+    auth: AuthorizationManagementClient,
+    scope: str,
+    principal_id: str,
+    principal_type: str = "ServicePrincipal",
+) -> None:
     role_def = next(
         auth.role_definitions.list(scope, filter=f"roleName eq '{ROLE_NAME}'"),
         None,
@@ -166,7 +172,7 @@ def _assign_role(auth: AuthorizationManagementClient, scope: str, principal_id: 
             {
                 "role_definition_id": role_def.id,
                 "principal_id": principal_id,
-                "principal_type": "ServicePrincipal",
+                "principal_type": principal_type,
             },
         )
         print(f"    granted to principal {principal_id}")
@@ -175,6 +181,26 @@ def _assign_role(auth: AuthorizationManagementClient, scope: str, principal_id: 
             print("    role already assigned (skipping)")
         else:
             raise
+
+
+def _resolve_host_principal() -> tuple[str, str]:
+    """Principal that boots the orchestrator sandbox (the host running this).
+
+    Interactive default: the signed-in az CLI user. For automation without
+    a signed-in user, set ACA_PRINCIPAL_ID, and optionally ACA_PRINCIPAL_TYPE
+    (defaults to ServicePrincipal).
+    """
+    override = os.environ.get("ACA_PRINCIPAL_ID")
+    if override:
+        return override, os.environ.get("ACA_PRINCIPAL_TYPE", "ServicePrincipal")
+    result = subprocess.run(
+        ["az", "ad", "signed-in-user", "show", "--query", "id", "-o", "tsv"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(f"error: could not resolve signed-in user: {result.stderr.strip()}")
+    return result.stdout.strip(), "User"
 
 
 def main() -> None:
@@ -210,20 +236,32 @@ def main() -> None:
             time.sleep(2)
             principal_id = (mgmt.get_group(orch_group).identity or {}).get("principalId")
         if not principal_id:
-            sys.exit("error: orchestrator group has no principalId — MI not enabled?")
+            sys.exit("error: orchestrator group has no principalId, MI not enabled?")
         print(f"    principalId: {principal_id}")
 
         # ---- 2. Worker group ----------------------------------------------
         print(f"==> Provisioning worker group {worker_group!r}...")
         mgmt.begin_create_group(worker_group, region).result()
 
-        # ---- 3. Grant Data Owner on worker-group scope only ---------------
+        # ---- 3. Grant Data Owner: MI on worker group, host on orchestrator group
         print(f"==> Granting {ROLE_NAME!r} on worker group → orchestrator MI...")
         worker_scope = (
             f"/subscriptions/{subscription}/resourceGroups/{resource_group}"
             f"/providers/Microsoft.App/sandboxGroups/{worker_group}"
         )
         _assign_role(auth, worker_scope, principal_id)
+
+        # The host created the orchestrator group fresh, so it has no
+        # data-plane grant there yet (setup only grants on the samples
+        # group). Grant the host Data Owner on the orchestrator group so it
+        # can boot the orchestrator sandbox below.
+        host_id, host_type = _resolve_host_principal()
+        print(f"==> Granting {ROLE_NAME!r} on orchestrator group → host {host_type.lower()}...")
+        orch_scope = (
+            f"/subscriptions/{subscription}/resourceGroups/{resource_group}"
+            f"/providers/Microsoft.App/sandboxGroups/{orch_group}"
+        )
+        _assign_role(auth, orch_scope, host_id, host_type)
 
         print(f"==> Waiting {RBAC_PROPAGATION_SECONDS}s for RBAC propagation...")
         time.sleep(RBAC_PROPAGATION_SECONDS)
@@ -281,7 +319,7 @@ def main() -> None:
 
         for r in payload:
             print(
-                f"    worker {r['worker']}: {r['elapsed_s']}s — "
+                f"    worker {r['worker']}: {r['elapsed_s']}s, "
                 f"{r['inside']:,} / {r['total']:,} inside"
             )
         total_inside = sum(r["inside"] for r in payload)

--- a/python/samples/04-swarms/02-shared-blob-memory/python/swarm.py
+++ b/python/samples/04-swarms/02-shared-blob-memory/python/swarm.py
@@ -1,4 +1,4 @@
-"""Swarm with shared-blob memory — sandbox inception + a sandbox-group AzureBlob volume.
+"""Swarm with shared-blob memory, sandbox inception + a sandbox-group AzureBlob volume.
 
 Same cross-group inception shape as
 ``../../01-sandbox-inception/python/swarm.py``: a host script provisions
@@ -17,11 +17,11 @@ worker group, mounts the same volume read-only, lists the prefix,
 reads every blob, and prints a single ``RESULT={json}`` line. This
 demonstrates three things that are otherwise hard to show:
 
-1. **Durable shared scratchpad** — the volume survives the workers
+1. **Durable shared scratchpad**, the volume survives the workers
    that wrote to it.
-2. **Cross-worker visibility without RPC** — siblings see each
+2. **Cross-worker visibility without RPC**, siblings see each
    other's partial state by listing a prefix.
-3. **Zero blob plumbing** — no storage account, no
+3. **Zero blob plumbing**, no storage account, no
    ``azure-storage-blob`` in the agent code, no RBAC on storage,
    no SAS / connection strings. Just ``open()``.
 
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import textwrap
 import time
@@ -99,8 +100,8 @@ SPAWN_WORKERS_SCRIPT = textwrap.dedent('''\
     DARTS        = int(os.environ["DARTS_PER_WORKER"])
     CHECKPOINT   = int(os.environ["CHECKPOINT_EVERY"])
 
-    # Per-worker script — runs inside the worker sandbox. Uses plain
-    # `open()` against the mounted shared volume — no blob SDK, no auth.
+    # Per-worker script, runs inside the worker sandbox. Uses plain
+    # `open()` against the mounted shared volume, no blob SDK, no auth.
     WORKER_PY = textwrap.dedent("""\\
         import json, os, random, sys
 
@@ -136,7 +137,7 @@ SPAWN_WORKERS_SCRIPT = textwrap.dedent('''\
         print(f"DONE worker={i} inside={inside} total={total} ckpts={len(checkpoints)}")
     """).strip()
 
-    # Aggregator script — runs inside the final aggregator sandbox AFTER
+    # Aggregator script, runs inside the final aggregator sandbox AFTER
     # the workers are deleted. Just lists the shared prefix and reads.
     AGGREGATOR_PY = textwrap.dedent("""\\
         import glob, json, os
@@ -169,7 +170,7 @@ SPAWN_WORKERS_SCRIPT = textwrap.dedent('''\
                 return f"FAIL worker={i} exit={result.exit_code} stderr={result.stderr[:400]}"
             return (result.stdout or "").strip().splitlines()[-1]
         finally:
-            # Worker sandbox is gone — but its scratchpad blob stays in the
+            # Worker sandbox is gone, but its scratchpad blob stays in the
             # shared volume. That's the whole point of this variant.
             await sandbox.delete()
 
@@ -245,7 +246,12 @@ def _load_env() -> None:
         )
 
 
-def _assign_role(auth: AuthorizationManagementClient, scope: str, principal_id: str) -> None:
+def _assign_role(
+    auth: AuthorizationManagementClient,
+    scope: str,
+    principal_id: str,
+    principal_type: str = "ServicePrincipal",
+) -> None:
     role_def = next(
         auth.role_definitions.list(scope, filter=f"roleName eq '{ROLE_NAME}'"),
         None,
@@ -261,7 +267,7 @@ def _assign_role(auth: AuthorizationManagementClient, scope: str, principal_id: 
                 {
                     "role_definition_id": role_def.id,
                     "principal_id": principal_id,
-                    "principal_type": "ServicePrincipal",
+                    "principal_type": principal_type,
                 },
             )
             return
@@ -277,6 +283,26 @@ def _assign_role(auth: AuthorizationManagementClient, scope: str, principal_id: 
     raise RuntimeError(f"role grant never succeeded: {last_exc}")
 
 
+def _resolve_host_principal() -> tuple[str, str]:
+    """Principal that boots the orchestrator sandbox (the host running this).
+
+    Interactive default: the signed-in az CLI user. For automation without
+    a signed-in user, set ACA_PRINCIPAL_ID, and optionally ACA_PRINCIPAL_TYPE
+    (defaults to ServicePrincipal).
+    """
+    override = os.environ.get("ACA_PRINCIPAL_ID")
+    if override:
+        return override, os.environ.get("ACA_PRINCIPAL_TYPE", "ServicePrincipal")
+    result = subprocess.run(
+        ["az", "ad", "signed-in-user", "show", "--query", "id", "-o", "tsv"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(f"error: could not resolve signed-in user: {result.stderr.strip()}")
+    return result.stdout.strip(), "User"
+
+
 def _wait_for_principal(mgmt: SandboxGroupManagementClient, group: str) -> str:
     for _ in range(10):
         identity = mgmt.get_group(group).identity or {}
@@ -284,7 +310,7 @@ def _wait_for_principal(mgmt: SandboxGroupManagementClient, group: str) -> str:
         if pid:
             return pid
         time.sleep(2)
-    sys.exit(f"error: group {group!r} has no principalId — MI not enabled?")
+    sys.exit(f"error: group {group!r} has no principalId, MI not enabled?")
 
 
 def main() -> None:
@@ -328,6 +354,19 @@ def main() -> None:
         )
         print(f"==> Granting {ROLE_NAME!r} on worker group → orchestrator MI...")
         _assign_role(auth, worker_group_scope, orch_pid)
+
+        # The host created the orchestrator group fresh, so it has no
+        # data-plane grant there yet (setup only grants on the samples
+        # group). Grant the host Data Owner on the orchestrator group so it
+        # can boot the orchestrator sandbox below.
+        host_id, host_type = _resolve_host_principal()
+        orch_group_scope = (
+            f"/subscriptions/{subscription}/resourceGroups/{resource_group}"
+            f"/providers/Microsoft.App/sandboxGroups/{orch_group}"
+        )
+        print(f"==> Granting {ROLE_NAME!r} on orchestrator group → host {host_type.lower()}...")
+        _assign_role(auth, orch_group_scope, host_id, host_type)
+
         print(f"==> Waiting {RBAC_PROPAGATION_SECONDS}s for RBAC propagation...")
         time.sleep(RBAC_PROPAGATION_SECONDS)
 

--- a/python/samples/04-swarms/02-shared-blob-memory/python/swarm.py
+++ b/python/samples/04-swarms/02-shared-blob-memory/python/swarm.py
@@ -355,10 +355,11 @@ def main() -> None:
         print(f"==> Granting {ROLE_NAME!r} on worker group → orchestrator MI...")
         _assign_role(auth, worker_group_scope, orch_pid)
 
-        # The host created the orchestrator group fresh, so it has no
-        # data-plane grant there yet (setup only grants on the samples
-        # group). Grant the host Data Owner on the orchestrator group so it
-        # can boot the orchestrator sandbox below.
+        # The host created both groups fresh, so it has no data-plane grant
+        # on either yet (setup only grants on the samples group). Grant the
+        # host Data Owner on the orchestrator group so it can boot the
+        # orchestrator sandbox, and on the worker group so it can create the
+        # shared volume below.
         host_id, host_type = _resolve_host_principal()
         orch_group_scope = (
             f"/subscriptions/{subscription}/resourceGroups/{resource_group}"
@@ -366,6 +367,8 @@ def main() -> None:
         )
         print(f"==> Granting {ROLE_NAME!r} on orchestrator group → host {host_type.lower()}...")
         _assign_role(auth, orch_group_scope, host_id, host_type)
+        print(f"==> Granting {ROLE_NAME!r} on worker group → host {host_type.lower()}...")
+        _assign_role(auth, worker_group_scope, host_id, host_type)
 
         print(f"==> Waiting {RBAC_PROPAGATION_SECONDS}s for RBAC propagation...")
         time.sleep(RBAC_PROPAGATION_SECONDS)

--- a/python/samples/10-connectors-email-triage/python/run.py
+++ b/python/samples/10-connectors-email-triage/python/run.py
@@ -24,7 +24,7 @@ Usage::
     uv run --extra connectors run.py --email path/to/your-email.json --dry-run
 
 ``--dry-run`` skips the actual ``copilot`` invocation and just prints
-the prompt + the egress policy it would apply — useful for iterating
+the prompt + the egress policy it would apply, useful for iterating
 on the prompt template alone.
 """
 
@@ -137,7 +137,7 @@ async def run(args: argparse.Namespace) -> int:
     prompt = _render_prompt(email, run_id)
 
     print("=" * 72)
-    print("LOCAL DEV — connectors-email-triage")
+    print("LOCAL DEV, connectors-email-triage")
     print("=" * 72)
     print(f"run id        : {run_id}")
     print(f"subject       : {email.get('subject', '(none)')[:80]}")
@@ -183,6 +183,13 @@ async def run(args: argparse.Namespace) -> int:
 
                 print("==> Applying egress policy (Deny + Allow + Transform)...")
                 await sandbox.set_egress_default("Deny")
+                # Transform rules below rewrite request headers, which
+                # requires full traffic inspection so the proxy can read
+                # and modify the request. Without it the Set-header
+                # transforms do not fire.
+                _policy = await sandbox.get_egress_policy()
+                _policy.traffic_inspection = "Full"
+                await sandbox.set_egress_policy(_policy)
                 await sandbox.add_egress_host_rule(host, action="Allow")
                 await sandbox.add_egress_transform_rule(
                     host=host,

--- a/python/samples/10-connectors-email-triage/receiver/app.py
+++ b/python/samples/10-connectors-email-triage/receiver/app.py
@@ -1,4 +1,4 @@
-"""Receiver — ACA app that boots a sandbox per inbound email event.
+"""Receiver, ACA app that boots a sandbox per inbound email event.
 
 Flow per webhook request:
 
@@ -17,7 +17,7 @@ Flow per webhook request:
 The Connector Gateway API key is fetched from an environment variable
 (``CONNECTOR_GATEWAY_API_KEY``) populated at deploy time by the
 post-deploy script (via the gateway's ``listapikey`` data-plane API).
-The key never enters the sandbox — it lives on the receiver and is
+The key never enters the sandbox, it lives on the receiver and is
 stamped onto outbound requests by the egress proxy.
 """
 
@@ -47,7 +47,7 @@ ACA_SANDBOX_GROUP_REGION = os.environ["ACA_SANDBOX_GROUP_REGION"]
 CONNECTOR_GATEWAY_ID = os.environ["CONNECTOR_GATEWAY_ID"]
 TEAMS_MCP_SERVER_CONFIG_NAME = os.environ["TEAMS_MCP_SERVER_CONFIG_NAME"]
 # Populated by post-deploy. While empty, the receiver still serves
-# health checks but rejects /webhook with 503 until the key arrives —
+# health checks but rejects /webhook with 503 until the key arrives,
 # this is how we avoid running with a broken egress Transform rule.
 CONNECTOR_GATEWAY_API_KEY = os.environ.get("CONNECTOR_GATEWAY_API_KEY", "").strip()
 # Required only when bypassing auth (local dev). In azd-deploy mode,
@@ -56,18 +56,18 @@ WEBHOOK_SHARED_SECRET = os.environ.get("WEBHOOK_SHARED_SECRET", "").strip()
 # GitHub PAT used to authenticate Copilot CLI to GitHub Models (the
 # LLM backend Copilot itself calls). Populated by post-deploy from the
 # `azd env set GITHUB_PAT ...` value. Like CONNECTOR_GATEWAY_API_KEY,
-# this never enters the sandbox — the egress proxy stamps it onto
+# this never enters the sandbox, the egress proxy stamps it onto
 # outbound requests to api.github.com and the two githubcopilot.com
 # hosts at the sandbox boundary.
 GITHUB_PAT = os.environ.get("GITHUB_PAT", "").strip()
 # Optional pre-pinned Teams target. When set, included in the prompt
 # so Copilot doesn't have to ask. When unset, the model is told to
-# look up the channel from its tools — fine for demo but unreliable.
+# look up the channel from its tools, fine for demo but unreliable.
 TEAMS_TEAM_ID = os.environ.get("TEAMS_TEAM_ID", "").strip()
 TEAMS_CHANNEL_ID = os.environ.get("TEAMS_CHANNEL_ID", "").strip()
 
 # GitHub host families Copilot CLI talks to that need an Authorization
-# header. Mirrors scenarios/02-coding-agents/gh-copilot-cli — *not*
+# header. Mirrors scenarios/02-coding-agents/gh-copilot-cli, *not*
 # adding explicit Allow rules for these hosts, because an Allow would
 # short-circuit the Transform and let the request out without the PAT.
 _GITHUB_TRANSFORM_HOSTS: tuple[tuple[str, str, str], ...] = (
@@ -102,7 +102,7 @@ _MCP_ENDPOINT_URL_CACHE: str = ""
 
 
 async def _discover_mcp_endpoint(credential: DefaultAzureCredential) -> str:
-    """ARM GET on the McpServerConfig — returns properties.mcpEndpointUrl."""
+    """ARM GET on the McpServerConfig, returns properties.mcpEndpointUrl."""
     arm = f"https://management.azure.com{CONNECTOR_GATEWAY_ID}/mcpserverconfigs/{TEAMS_MCP_SERVER_CONFIG_NAME}?api-version=2026-05-01-preview"
     token = (await credential.get_token("https://management.azure.com/.default")).token
     async with httpx.AsyncClient(timeout=30.0) as client:
@@ -178,7 +178,7 @@ async def healthz() -> Response:
 
 @app.post("/webhook")
 async def webhook(request: Request) -> dict[str, Any]:
-    # Auth — system-key style for the preview/dev shape. Production
+    # Auth, system-key style for the preview/dev shape. Production
     # should put App Service built-in auth in front of this endpoint
     # and validate an Entra token issued by the gateway's MI; the
     # comment block in the Bicep covers the upgrade path.
@@ -249,7 +249,7 @@ async def _process_one(email: dict[str, Any]) -> None:
 
         await _wait_exec(sandbox)
 
-        # Install Copilot CLI before the egress lockdown — installer
+        # Install Copilot CLI before the egress lockdown, installer
         # hits gh.io etc., which the Deny default would block.
         await _install_copilot(sandbox, run_id)
 
@@ -276,7 +276,7 @@ async def _process_one(email: dict[str, Any]) -> None:
 
 
 async def _wait_exec(sandbox, *, timeout_s: float = 30.0) -> None:
-    """Poll sandbox.exec('true') until it returns 0 — equivalent to
+    """Poll sandbox.exec('true') until it returns 0, equivalent to
     waiting for the per-VM runtime to be reachable."""
     loop = asyncio.get_event_loop()
     deadline = loop.time() + timeout_s
@@ -302,9 +302,15 @@ async def _install_copilot(sandbox, run_id: str) -> None:
 async def _apply_egress_policy(sandbox) -> None:
     mcp_host = _mcp_host()
     await sandbox.set_egress_default("Deny")
+    # The Transform rules below rewrite request headers, which requires
+    # full traffic inspection so the proxy can read and modify the
+    # request. Without it the Set-header transforms do not fire.
+    policy = await sandbox.get_egress_policy()
+    policy.traffic_inspection = "Full"
+    await sandbox.set_egress_policy(policy)
     # MCP host Transform implicitly allows the request through AND
     # stamps the gateway API key. Don't ALSO add a host-allow rule for
-    # the MCP host — a host-allow + Transform on the same host
+    # the MCP host, a host-allow + Transform on the same host
     # short-circuits the Transform.
     await sandbox.add_egress_transform_rule(
         host=mcp_host,
@@ -315,7 +321,7 @@ async def _apply_egress_policy(sandbox) -> None:
         )],
         name="mcp-api-key",
     )
-    # GitHub PAT injection — Copilot CLI needs to authenticate to
+    # GitHub PAT injection, Copilot CLI needs to authenticate to
     # GitHub Models (its LLM backend) and the GitHub auth/API host.
     # If GITHUB_PAT isn't set the egress lockdown still applies but
     # copilot will error 'No authentication information found' on
@@ -334,7 +340,7 @@ async def _apply_egress_policy(sandbox) -> None:
             )
     else:
         log.warning(
-            "GITHUB_PAT is not set — Copilot CLI will fail to authenticate "
+            "GITHUB_PAT is not set, Copilot CLI will fail to authenticate "
             "with GitHub Models. Set it via `azd env set GITHUB_PAT <token>` "
             "and re-run azd hooks run postdeploy."
         )
@@ -366,7 +372,7 @@ async def _stage_prompt(sandbox, email: dict[str, Any], run_id: str) -> None:
     await sandbox.exec("mkdir -p /root/.copilot")
     await sandbox.write_file("/root/.copilot/mcp-config.json", mcp_json.encode("utf-8"))
 
-    # Triage prompt — small, deterministic.  See prompts/triage.md for
+    # Triage prompt, small, deterministic.  See prompts/triage.md for
     # the canonical source.
     prompt = _render_prompt(email, run_id)
     await sandbox.write_file("/tmp/prompt.md", prompt.encode("utf-8"))
@@ -386,7 +392,7 @@ def _render_prompt(email: dict[str, Any], run_id: str) -> str:
             f"  teamId:    {TEAMS_TEAM_ID}\n"
             f"  channelId: {TEAMS_CHANNEL_ID}\n"
             "  content:   <your triage card text>\n"
-            "Do not call ListTeams or ListChannels — the IDs above are "
+            "Do not call ListTeams or ListChannels, the IDs above are "
             "already correct. Use plain text content (no HTML). Do not "
             "invent any other recipients."
         )
@@ -407,7 +413,7 @@ def _render_prompt(email: dict[str, Any], run_id: str) -> str:
 
 async def _run_copilot(sandbox, run_id: str) -> None:
     log.info("[%s] running copilot...", run_id)
-    # Diagnostic — show copilot version + a quick auth status check
+    # Diagnostic, show copilot version + a quick auth status check
     # before the real run, so when something's wrong we can tell whether
     # it's an auth issue vs a network issue vs the prompt itself.
     v = await sandbox.exec("timeout 10s bash -lc 'copilot --version 2>&1 || true'")
@@ -420,7 +426,7 @@ async def _run_copilot(sandbox, run_id: str) -> None:
 
     # TRADE-OFF: Copilot CLI v1 errors immediately if no credential is
     # present in its env (COPILOT_GITHUB_TOKEN / GH_TOKEN / GITHUB_TOKEN)
-    # — it does NOT attempt a network call first. That means the egress
+    # it does NOT attempt a network call first. That means the egress
     # proxy's Transform rule on api.github.com can't intervene to inject
     # the PAT, because Copilot never reaches the network. For
     # non-interactive use we have to put the PAT in the sandbox env
@@ -428,7 +434,7 @@ async def _run_copilot(sandbox, run_id: str) -> None:
     # requests as defense-in-depth, but the sandbox sees the PAT.
     #
     # If you can't accept that trade-off, this scenario isn't the right
-    # fit — switch to scenario 11 (Python tool-calling against AOAI via
+    # fit, switch to scenario 11 (Python tool-calling against AOAI via
     # the egress proxy, no PAT in the sandbox).
     pat_env = ""
     if GITHUB_PAT:
@@ -437,7 +443,7 @@ async def _run_copilot(sandbox, run_id: str) -> None:
     r = await sandbox.exec(
         f"timeout 240s bash -lc '{pat_env}copilot --allow-all-tools -p \"$(cat /tmp/prompt.md)\" 2>&1'"
     )
-    # Don't truncate — when Copilot fails its message includes the full
+    # Don't truncate, when Copilot fails its message includes the full
     # error contract that tells us what to fix next (auth, network, etc.).
     log.info(
         "[%s] copilot exit=%d\nstdout:\n%s\n[--- end stdout ---]",

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,15 +1,13 @@
 """Offline gate: structural invariants for the samples tree.
 
-The plain asserts below hold on main today and must stay green. The
-three xfail specs at the bottom document confirmed audit gaps: they
-currently fail, so xfail keeps the gate green while tracking them. When
-each fix lands the spec xpasses and we flip it to a hard assert.
+The plain asserts below hold on main and must stay green. The three
+specs at the bottom encode audit findings A1, A2, and A3; the fixes
+have landed, so they now assert hard.
 """
 
 import re
 import tomllib
 
-import pytest
 import yaml
 
 from conftest import (
@@ -76,14 +74,13 @@ def test_pyproject_declares_expected_extras():
         assert expected in extras, f"missing extra: {expected}"
 
 
-# --- confirmed audit gaps (currently failing) -----------------------------
+# --- audit findings A1, A2, A3 (fixed) ------------------------------------
 
 RAW_INSTALL_RE = re.compile(
     r"raw\.githubusercontent\.com/[^\s\"']*install\.(?:sh|ps1)"
 )
 
 
-@pytest.mark.xfail(strict=False, reason="A1 install URL divergence, see audit")
 def test_a1_install_url_uses_aka_ms():
     offenders = []
     targets = tracked_md_files() + _cli_run_shell_files()
@@ -102,9 +99,6 @@ NAME_FLAG_RE = re.compile(
 )
 
 
-@pytest.mark.xfail(
-    strict=False, reason="A2 --name rejected by aca CLI, must be --group"
-)
 def test_a2_sandboxgroup_subcommands_use_group_flag():
     offenders = []
     for path in _cli_run_shell_files():
@@ -127,10 +121,6 @@ def _has_transform_rule(doc) -> bool:
     return False
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason="A3 missing trafficInspection: Full on Transform policy",
-)
 def test_a3_deny_transform_policy_sets_traffic_inspection():
     offenders = []
     for path in _cli_egress_yaml_files():


### PR DESCRIPTION
Remediates the four conformance findings from the recent samples audit (issues #4, #5, #6, #2). Each fix is verified against the current `aca` CLI / SDK behavior.

## A1, install URLs (issue #6)
The old `raw.githubusercontent.com/.../docs/early/aca-cli/install.{sh,ps1}` paths now 404. Repoint all references to `https://aka.ms/aca-cli-install` (and `-ps` for PowerShell).

Removed the two "Pin a specific version" subsections in `cli/README.md`: the current installer auto-pins from a SHA-verified `latest-version.txt` and no longer accepts `ACA_VERSION` or `-Version`, so those snippets documented flags that no longer exist. Uninstall is preserved against the aka.ms URLs.

## A2, sandboxgroup flag (issue #4)
`aca sandboxgroup identity assign`, `identity show`, and `role create` require `--group`, not `--name`. Fixed the three identity/role calls in each `04-swarms` `run.sh`. The `create`, `delete`, and `volume create/delete` calls legitimately take `--name` and are left as-is.

## A3, egress traffic inspection (issue #5)
A Deny-default egress policy that uses Transform rules needs `trafficInspection: Full` so the proxy can read and rewrite request headers; without it the header transforms never fire. Added it to the `gh-copilot-cli` `policy.yaml` and to the SDK egress builders in `10-connectors-email-triage` (`run.py` and the receiver).

## Issue #2, 04-swarm host grant
The swarm host creates a fresh orchestrator group, so it has no data-plane grant there (setup only grants Data Owner on the samples group). The host then tries to boot the orchestrator sandbox in that group and would hit 403.

Fix: after creating the orchestrator group, grant the host Data Owner on it before booting the orchestrator sandbox. The python path adds a `principal_type` parameter to `_assign_role` and a host-principal resolver (honoring `ACA_PRINCIPAL_ID` / `ACA_PRINCIPAL_TYPE` for non-interactive automation, defaulting to the signed-in user); the CLI path adds the matching `aca sandboxgroup role create ... --group "$ORCH_GROUP"`. Applied to both `01-sandbox-inception` and `02-shared-blob-memory`.

## Tests + CI
- Flipped the three conformance specs in `tests/test_conformance.py` from `xfail` to hard asserts now that the fixes land. Offline suite: 48 passed.
- Bumped CI actions to node24 versions (`checkout@v5`, `setup-uv@v7`, `azure/login@v3`) to clear the node20 deprecation warnings.
- Removed em-dashes from all touched files.

Live 04-swarm verification (CLI + python) to follow before merge.
