### PR TITLE
Add missing worker scripts for 05-data-processing

### DIFF
--- a/python/samples/05-data-processing/README.md
+++ b/python/samples/05-data-processing/README.md
@@ -157,7 +157,7 @@ Tune the workload with environment variables before launching:
 ```text
 ==> Booting aggregator (reads /mnt/shared/processed/, writes summary)...
     aggregator: 11111111-2222-3333-4444-555555555555
-    staged aggregator.py into 11111111… (2,863 bytes)
+    staged aggregator.py into 11111111… (2,441 bytes)
     ▶ exec on 11111111…: aggregator.py
 
 ========================================================================
@@ -165,20 +165,20 @@ PIPELINE REPORT
 ========================================================================
   files read         : 20
   total events       : 2,000
-  revenue events     : 81
-  total value        : 100,420.31
-  avg value / event  : 50.2102
+  revenue events     : 82
+  total value        : 20,249.77
+  avg value / event  : 10.1249
 
   events by type:
-    page_view       1,202
-    click             508
-    logout            205
-    purchase           81
-    signup              4
+    page_view       1,197
+    click             519
+    logout            179
+    purchase           82
+    signup             23
 
   top 10 users by event count:
-    u0042       29
-    u0087       28
+    u0064       31
+    u0036       31
     ...
 
 ==> Done.

--- a/python/samples/05-data-processing/python/workers/aggregator.py
+++ b/python/samples/05-data-processing/python/workers/aggregator.py
@@ -1,0 +1,78 @@
+"""Aggregator worker: summarises the processed batches into one report.
+
+Runs once, in a third sandbox, after the producer and transformer have
+drained. It globs ``processed/batch-*.jsonl``, folds every event into a
+handful of counters, writes ``summary/report.json`` to the volume, and
+prints a single ``RESULT={json}`` line on stdout for the host to parse.
+
+Pure stdlib (``glob`` + ``json`` + ``collections``). No Azure SDK, no
+network. The host (``pipeline.py``) reads the ``RESULT=`` line and renders
+the final report.
+
+Config (environment, set by ``pipeline.py``):
+
+    MOUNTPOINT  shared volume mount  (default /mnt/shared)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections import Counter
+from pathlib import Path
+
+MOUNT = Path(os.environ.get("MOUNTPOINT", "/mnt/shared"))
+PROCESSED = MOUNT / "processed"
+SUMMARY = MOUNT / "summary"
+
+TOP_N_USERS = 10
+TOP_N_HOURS = 10
+
+
+def main() -> int:
+    files = sorted(PROCESSED.glob("batch-*.jsonl"))
+
+    events_total = 0
+    revenue_events = 0
+    total_value = 0.0
+    by_type: Counter[str] = Counter()
+    by_user: Counter[str] = Counter()
+    by_hour: Counter[int] = Counter()
+
+    for path in files:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            event = json.loads(line)
+            events_total += 1
+            by_type[event["type"]] += 1
+            by_user[event["user"]] += 1
+            by_hour[int(event["hour"])] += 1
+            value = float(event.get("value", 0) or 0)
+            if value > 0:
+                revenue_events += 1
+                total_value += value
+
+    report = {
+        "files_read": len(files),
+        "events_total": events_total,
+        "revenue_events": revenue_events,
+        "total_value": round(total_value, 2),
+        "avg_value": round(total_value / events_total, 4) if events_total else 0.0,
+        "events_by_type": dict(by_type.most_common()),
+        "top_users": [[u, n] for u, n in by_user.most_common(TOP_N_USERS)],
+        "top_hours": [[h, n] for h, n in by_hour.most_common(TOP_N_HOURS)],
+    }
+
+    SUMMARY.mkdir(parents=True, exist_ok=True)
+    tmp = SUMMARY / ".report.json.tmp"
+    tmp.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    os.replace(tmp, SUMMARY / "report.json")
+
+    print("RESULT=" + json.dumps(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/samples/05-data-processing/python/workers/producer.py
+++ b/python/samples/05-data-processing/python/workers/producer.py
@@ -1,0 +1,108 @@
+"""Producer worker: streams synthetic event batches onto the shared volume.
+
+Runs inside a sandbox with ``/mnt/shared`` mounted. Pure stdlib, no
+Azure SDK and no network. Each batch is written to a temp file and then
+``os.replace``d into place so a reader globbing ``raw/batch-*.jsonl``
+never catches a half-written file. When every batch is on disk the
+producer drops a ``.producer-done`` sentinel so the transformer knows the
+stream has ended.
+
+Config comes from environment variables set by the host (``pipeline.py``):
+
+    MOUNTPOINT        shared volume mount    (default /mnt/shared)
+    BATCHES           number of batches      (default 20)
+    EVENTS_PER_BATCH  events per batch        (default 100)
+    BATCH_DELAY_S     sleep between batches   (default 0.5)
+    SEED              RNG seed for repeatable output (default 42)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import sys
+import time
+from pathlib import Path
+
+MOUNT = Path(os.environ.get("MOUNTPOINT", "/mnt/shared"))
+RAW = MOUNT / "raw"
+
+BATCHES = int(os.environ.get("BATCHES", "20"))
+EVENTS_PER_BATCH = int(os.environ.get("EVENTS_PER_BATCH", "100"))
+BATCH_DELAY_S = float(os.environ.get("BATCH_DELAY_S", "0.5"))
+SEED = int(os.environ.get("SEED", "42"))
+
+# A fixed base epoch keeps the generated timestamps (and therefore the
+# hour-of-day histogram) deterministic for a given seed.
+BASE_TS = 1_700_000_000  # 2023-11-14T22:13:20Z
+WINDOW_S = 7 * 24 * 60 * 60  # spread events across a week
+
+USERS = [f"u{i:04d}" for i in range(100)]
+EVENT_TYPES = [
+    ("page_view", 0.60),
+    ("click", 0.25),
+    ("logout", 0.10),
+    ("purchase", 0.04),
+    ("signup", 0.01),
+]
+
+
+def _weighted_type(rnd: random.Random) -> str:
+    roll = rnd.random()
+    cumulative = 0.0
+    for name, weight in EVENT_TYPES:
+        cumulative += weight
+        if roll < cumulative:
+            return name
+    return EVENT_TYPES[-1][0]
+
+
+def _make_event(rnd: random.Random, batch: int, idx: int) -> dict:
+    etype = _weighted_type(rnd)
+    event = {
+        "id": f"{batch:03d}-{idx:04d}",
+        "ts": BASE_TS + rnd.randint(0, WINDOW_S),
+        "user": rnd.choice(USERS),
+        "type": etype,
+    }
+    if etype == "purchase":
+        event["value"] = round(rnd.uniform(5.0, 500.0), 2)
+    return event
+
+
+def _write_batch(batch: int, events: list[dict]) -> Path:
+    """Atomically publish one batch as JSONL."""
+    final = RAW / f"batch-{batch:03d}.jsonl"
+    tmp = RAW / f".batch-{batch:03d}.jsonl.tmp"
+    payload = "".join(json.dumps(e) + "\n" for e in events)
+    tmp.write_text(payload, encoding="utf-8")
+    os.replace(tmp, final)
+    return final
+
+
+def main() -> int:
+    RAW.mkdir(parents=True, exist_ok=True)
+    rnd = random.Random(SEED)
+
+    total = 0
+    for batch in range(BATCHES):
+        events = [_make_event(rnd, batch, i) for i in range(EVENTS_PER_BATCH)]
+        path = _write_batch(batch, events)
+        total += len(events)
+        print(f"produced {path.name}  ({len(events)} events)")
+        if batch < BATCHES - 1:
+            time.sleep(BATCH_DELAY_S)
+
+    # Sentinel: written last, atomically, so the transformer only sees it
+    # after every batch is durable on the volume.
+    sentinel_tmp = RAW / ".producer-done.tmp"
+    sentinel_tmp.write_text(str(total), encoding="utf-8")
+    os.replace(sentinel_tmp, RAW / ".producer-done")
+
+    print(f"producer done: {BATCHES} batches, {total} events")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/samples/05-data-processing/python/workers/transformer.py
+++ b/python/samples/05-data-processing/python/workers/transformer.py
@@ -1,0 +1,100 @@
+"""Transformer worker: drains raw batches, enriches them, archives sources.
+
+Runs concurrently with the producer in a second sandbox on the same
+shared volume. It polls ``raw/batch-*.jsonl``; for each new batch it
+enriches every event, writes the result to ``processed/batch-NNN.jsonl``
+(atomically), then moves the source into ``raw/.done/`` so it is never
+re-processed. It exits once the producer has dropped ``.producer-done``
+and a couple of poll cycles go by with nothing new to do.
+
+Enrichment is deliberately simple and pure stdlib: it derives the
+UTC hour-of-day from the event timestamp and flags revenue events. The
+aggregator reads these derived fields, so the contract between the two
+workers lives entirely in the JSONL on the volume.
+
+Config (environment, set by ``pipeline.py``):
+
+    MOUNTPOINT  shared volume mount  (default /mnt/shared)
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+MOUNT = Path(os.environ.get("MOUNTPOINT", "/mnt/shared"))
+RAW = MOUNT / "raw"
+DONE = RAW / ".done"
+PROCESSED = MOUNT / "processed"
+SENTINEL = RAW / ".producer-done"
+
+POLL_INTERVAL_S = 0.25
+# Number of consecutive empty polls (after the producer is done) we wait
+# before declaring the stream fully drained.
+QUIET_POLLS_TO_STOP = 3
+
+
+def _enrich(event: dict) -> dict:
+    ts = float(event.get("ts", 0))
+    hour = dt.datetime.fromtimestamp(ts, tz=dt.timezone.utc).hour
+    value = float(event.get("value", 0) or 0)
+    return {
+        **event,
+        "hour": hour,
+        "revenue": value > 0,
+        "value": value,
+    }
+
+
+def _transform_batch(src: Path) -> int:
+    events = [
+        _enrich(json.loads(line))
+        for line in src.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    out = PROCESSED / src.name
+    tmp = PROCESSED / f".{src.name}.tmp"
+    tmp.write_text(
+        "".join(json.dumps(e) + "\n" for e in events), encoding="utf-8"
+    )
+    os.replace(tmp, out)
+    # Archive the source rather than deleting it (replayable, idempotent).
+    os.replace(src, DONE / src.name)
+    return len(events)
+
+
+def main() -> int:
+    for d in (RAW, DONE, PROCESSED):
+        d.mkdir(parents=True, exist_ok=True)
+
+    processed_files = 0
+    processed_events = 0
+    quiet_polls = 0
+
+    while True:
+        batches = sorted(RAW.glob("batch-*.jsonl"))
+        if batches:
+            quiet_polls = 0
+            for src in batches:
+                count = _transform_batch(src)
+                processed_files += 1
+                processed_events += count
+                print(f"transformed {src.name} -> processed/  ({count} events)")
+            continue
+
+        if SENTINEL.exists():
+            quiet_polls += 1
+            if quiet_polls >= QUIET_POLLS_TO_STOP:
+                break
+        time.sleep(POLL_INTERVAL_S)
+
+    print(f"transformer done: {processed_files} batches, {processed_events} events")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

The `05-data-processing` pipeline sample shipped without the three worker scripts its host (`python/pipeline.py`) stages into the sandboxes. Running it failed immediately:

```
FileNotFoundError: .../05-data-processing/python/workers/producer.py
```

The `workers/` directory was never present in the repo, so the sample has been broken on `main`. The README already documents all three workers and the directory conventions they coordinate through; this PR adds the implementations to match that contract.

## Changes

Adds three pure-stdlib workers (no Azure SDK, no network, no SAS tokens, consistent with the sample premise that the mount is the API):

- `workers/producer.py` generates deterministic, seeded event batches, writes each batch atomically (`tmp` + `os.replace`) to `raw/batch-NNN.jsonl`, and drops the `.producer-done` sentinel when finished.
- `workers/transformer.py` polls `raw/`, enriches each batch (derives UTC hour, flags revenue events), writes `processed/batch-NNN.jsonl` atomically, archives the source into `raw/.done/`, and exits once the producer is done and the stream is quiet.
- `workers/aggregator.py` folds `processed/` into a report, writes `summary/report.json`, and prints the `RESULT={json}` line the host parses.

Also updates the README "Expected output" tail to the real, reproducible `seed=42` numbers these workers produce.

## Verification

Ran end to end against a live sandbox group: 20 batches, 2000 events, report rendered, all three sandboxes and the shared volume cleaned up. Offline test suite stays green.
