### PR TITLE
Use aka.ms aca CLI install short link in sample app pages

### DIFF
--- a/cli/samples/01-webapps/simple-anonymous/app/server.js
+++ b/cli/samples/01-webapps/simple-anonymous/app/server.js
@@ -403,10 +403,10 @@ function page() {
     </div>
 
     <pre id="snippet-cli" class="tab-pane block p-6 text-sm overflow-x-auto text-slate-100"><span class="text-slate-500"># Install (Linux / macOS)</span>
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
+curl -fsSL https://aka.ms/aca-cli-install | sh
 
 <span class="text-slate-500"># Install (Windows PowerShell)</span>
-<span class="text-slate-500"># irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1 | iex</span>
+<span class="text-slate-500"># irm https://aka.ms/aca-cli-install-ps | iex</span>
 
 <span class="text-slate-500"># 0. Login to Azure</span>
 az login

--- a/python/samples/01-webapps/simple-anonymous/app/server.js
+++ b/python/samples/01-webapps/simple-anonymous/app/server.js
@@ -403,10 +403,10 @@ function page() {
     </div>
 
     <pre id="snippet-cli" class="tab-pane block p-6 text-sm overflow-x-auto text-slate-100"><span class="text-slate-500"># Install (Linux / macOS)</span>
-curl -fsSL https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.sh | sh
+curl -fsSL https://aka.ms/aca-cli-install | sh
 
 <span class="text-slate-500"># Install (Windows PowerShell)</span>
-<span class="text-slate-500"># irm https://raw.githubusercontent.com/microsoft/azure-container-apps/main/docs/early/aca-cli/install.ps1 | iex</span>
+<span class="text-slate-500"># irm https://aka.ms/aca-cli-install-ps | iex</span>
 
 <span class="text-slate-500"># 0. Login to Azure</span>
 az login


### PR DESCRIPTION
## Summary

The READMEs and swarm `run.sh` scripts already use the documented `https://aka.ms/aca-cli-install` short link, but two sample app pages still rendered the raw `raw.githubusercontent.com/microsoft/azure-container-apps/.../install.sh` (and `.ps1`) URL in their in-app install snippet. This standardizes those last two spots.

## Changes

- `cli/samples/01-webapps/simple-anonymous/app/server.js` — install snippet now uses `https://aka.ms/aca-cli-install` / `https://aka.ms/aca-cli-install-ps`
- `python/samples/01-webapps/simple-anonymous/app/server.js` — same fix

The repo is now fully consistent on the documented short link.

Fixes #6